### PR TITLE
Add support for nesting in cmake bundles

### DIFF
--- a/cmake/cpp_bindgen.cmake.in
+++ b/cmake/cpp_bindgen.cmake.in
@@ -30,6 +30,8 @@ include_guard(GLOBAL)
 
 option(GT_ENABLE_BINDINGS_GENERATION "If turned off, bindings will not be generated." ON)
 
+if( NOT TARGET cpp_bindgen_interface )
+
 # variables are unset after use for scoping, they need to be redefined in the macros
 set(__CPP_BINDGEN_SOURCE_DIR @__CPP_BINDGEN_SOURCE_DIR@)
 set(__CPP_BINDGEN_INCLUDE_DIR @__CPP_BINDGEN_INCLUDE_DIR@)
@@ -42,16 +44,18 @@ if(CPP_BINDGEN_GT_LEGACY)
     target_compile_definitions(cpp_bindgen_interface INTERFACE CPP_BINDGEN_GT_LEGACY)
 endif()
 
-add_library(cpp_bindgen_generator ${__CPP_BINDGEN_SOURCE_DIR}/cpp_bindgen/generator.cpp)
+add_library(cpp_bindgen_generator STATIC ${__CPP_BINDGEN_SOURCE_DIR}/cpp_bindgen/generator.cpp)
 # PUBLIC to make export.hpp available in the sources passed to add_bindings_library()
 target_link_libraries(cpp_bindgen_generator PUBLIC Boost::boost)
 target_link_libraries(cpp_bindgen_generator PUBLIC cpp_bindgen_interface)
 
-add_library(cpp_bindgen_handle ${__CPP_BINDGEN_SOURCE_DIR}/cpp_bindgen/handle.cpp)
+add_library(cpp_bindgen_handle STATIC ${__CPP_BINDGEN_SOURCE_DIR}/cpp_bindgen/handle.cpp)
 target_link_libraries(cpp_bindgen_handle PUBLIC cpp_bindgen_interface)
 
 unset(__CPP_BINDGEN_SOURCE_DIR)
 unset(__CPP_BINDGEN_INCLUDE_DIR)
+
+endif()
 
 # bindgen_enable_fortran_library()
 #
@@ -115,7 +119,7 @@ function(bindgen_add_library target_name)
         set(bindings_fortran_decl_filename ${CMAKE_CURRENT_LIST_DIR}/${target_name}.f90) # default value
     endif()
 
-    add_library(${target_name} ${ARG_SOURCES})
+    add_library(${target_name} STATIC ${ARG_SOURCES})
     target_link_libraries(${target_name} PRIVATE cpp_bindgen_generator)
 
     if(GT_ENABLE_BINDINGS_GENERATION)

--- a/cmake/cpp_bindgen.cmake.in
+++ b/cmake/cpp_bindgen.cmake.in
@@ -30,6 +30,7 @@ include_guard(GLOBAL)
 
 option(GT_ENABLE_BINDINGS_GENERATION "If turned off, bindings will not be generated." ON)
 
+# in some conditions the include guard above doesn't work
 if( NOT TARGET cpp_bindgen_interface )
 
 # variables are unset after use for scoping, they need to be redefined in the macros


### PR DESCRIPTION
Also avoid RPATH mess when building bundle with BUILD_SHARED_LIBS=ON
by compiling bindings with STATIC

Without the STATIC I received errors like "could not find libcpp_bind_generator.so" during generation, as the RPATH is not encoded.