### PR TITLE
End module with `end module`

### DIFF
--- a/src/cpp_bindgen/generator.cpp
+++ b/src/cpp_bindgen/generator.cpp
@@ -162,6 +162,6 @@ namespace cpp_bindgen {
         strm << get_fortran_generics();
         strm << "contains\n";
         strm << _impl::get_entities<_impl::fortran_wrapper_traits>();
-        strm << "end\n";
+        strm << "end module\n";
     }
 } // namespace cpp_bindgen

--- a/tests/regression/array/bindgen_regression_array.f90
+++ b/tests/regression/array/bindgen_regression_array.f90
@@ -26,4 +26,4 @@ contains
 
       call fill_array_impl(descriptor0)
     end subroutine
-end
+end module

--- a/tests/regression/array/bindgen_regression_array_cu.f90
+++ b/tests/regression/array/bindgen_regression_array_cu.f90
@@ -49,4 +49,4 @@ contains
 
       call fill_gpu_array_impl(descriptor0)
     end subroutine
-end
+end module

--- a/tests/regression/simple/bindgen_regression_simple.f90
+++ b/tests/regression/simple/bindgen_regression_simple.f90
@@ -11,4 +11,4 @@ implicit none
 
   end interface
 contains
-end
+end module

--- a/tests/unit_tests/test_export.cpp
+++ b/tests/unit_tests/test_export.cpp
@@ -233,7 +233,7 @@ contains
 
       call test_cpp_bindgen_and_wrapper_compatible_type_b_impl(arg0, descriptor1)
     end subroutine
-end
+end module
 )?";
 
     TEST(export, fortran_interface) {

--- a/tests/unit_tests/test_generator.cpp
+++ b/tests/unit_tests/test_generator.cpp
@@ -98,7 +98,7 @@ contains
 
       call qux_impl(arg0, descriptor1)
     end subroutine
-end
+end module
 )?";
 
         TEST(generator, fortran_interface) {


### PR DESCRIPTION
Makes cpp_bindgen compatible with Serialbox's pp_ser.

Fixes #50.